### PR TITLE
Add an Alpine target with bash, shadow system, and an alpine user

### DIFF
--- a/alpine38/Dockerfile
+++ b/alpine38/Dockerfile
@@ -1,0 +1,27 @@
+FROM alpine:3.8
+
+RUN \
+  apk add --no-cache \
+    bash \
+    bash-completion \
+    openrc \
+    openssh \
+    python \
+    shadow \
+    sudo && \
+# create user - alpine - for ssh access and enable sudo operations \
+  addgroup -S alpine && \
+  adduser -S alpine -G alpine -s /bin/bash -h /home/alpine && \
+  usermod -p alpine alpine && \
+  echo 'alpine ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
+  su - alpine -c "mkdir -p ~/.ssh && chmod 0700 ~/.ssh && chmod -s ~/.ssh" && \
+# Various options to make SSH access easier when testing Ansible playbooks \
+# also make the keys that the sshd daemon needs \
+  sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && \
+  sed -i "s/StrictModes.*/StrictModes no/g" /etc/ssh/sshd_config && \
+  /usr/bin/ssh-keygen -A
+
+COPY docker-entrypoint.sh /
+CMD ["/docker-entrypoint.sh"]
+
+EXPOSE 22

--- a/alpine38/docker-entrypoint.sh
+++ b/alpine38/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# # enable syslog daemon so that SSHD log file is created
+syslogd
+
+# start SSH daemon
+/usr/sbin/sshd -D

--- a/alpine38/test.bats
+++ b/alpine38/test.bats
@@ -1,0 +1,4 @@
+@test "Can build Alpine 3.8" {
+  run docker build ./
+  [ $status -eq 0 ]
+}


### PR DESCRIPTION
Adds an Alpine 3.8 target with an alpine user (in place of ubuntu user). 

Also has a very simple [BATS](https://github.com/bats-core/bats-core) test file at `./alpine38/test.bats`